### PR TITLE
`typesafe-i18n` improvements

### DIFF
--- a/src/i18n/fr/index.ts
+++ b/src/i18n/fr/index.ts
@@ -1,6 +1,6 @@
-import type { BaseTranslation } from "typesafe-i18n";
+import type { Translation } from "../i18n-types";
 
-const fr: BaseTranslation = {
+const fr: Translation = {
   VIEWS_LOGIN_EMAIL_LABEL: "Votre adresse mél",
   VIEWS_LOGIN_EMAIL_HELP: "Nous ne partagerons votre email avec personne.",
   VIEWS_LOGIN_PASSWORD: "Mot de passe",


### PR DESCRIPTION
I just saw you are using `typesafe-i18n` in your repo.
The type `BaseTranslation` should only be used for your base translation. All other translations should use the generated `Translation` type, to get better TypeScript support.